### PR TITLE
Previews were crashing on an M1 Max Mac running Ventura 13.1.

### DIFF
--- a/SwiftUI/project7/FastTrack.xcodeproj/project.pbxproj
+++ b/SwiftUI/project7/FastTrack.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		38D095CF298E335D00BE2A79 /* Track+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38D095CE298E335D00BE2A79 /* Track+Preview.swift */; };
 		51F60ABC2808457D007647DC /* FastTrackApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F60ABB2808457D007647DC /* FastTrackApp.swift */; };
 		51F60ABE2808457D007647DC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F60ABD2808457D007647DC /* ContentView.swift */; };
 		51F60AC02808457F007647DC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 51F60ABF2808457F007647DC /* Assets.xcassets */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		38D095CE298E335D00BE2A79 /* Track+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Track+Preview.swift"; sourceTree = "<group>"; };
 		51F60AB82808457D007647DC /* FastTrack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FastTrack.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		51F60ABB2808457D007647DC /* FastTrackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FastTrackApp.swift; sourceTree = "<group>"; };
 		51F60ABD2808457D007647DC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 		51F60AC12808457F007647DC /* Preview Content */ = {
 			isa = PBXGroup;
 			children = (
+				38D095CE298E335D00BE2A79 /* Track+Preview.swift */,
 				51F60AC22808457F007647DC /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
@@ -147,6 +150,7 @@
 			files = (
 				51F60ABE2808457D007647DC /* ContentView.swift in Sources */,
 				51F60ABC2808457D007647DC /* FastTrackApp.swift in Sources */,
+				38D095CF298E335D00BE2A79 /* Track+Preview.swift in Sources */,
 				51F60ACD28084731007647DC /* TrackView.swift in Sources */,
 				51F60ACB28084607007647DC /* Track.swift in Sources */,
 			);

--- a/SwiftUI/project7/FastTrack/Preview Content/Track+Preview.swift
+++ b/SwiftUI/project7/FastTrack/Preview Content/Track+Preview.swift
@@ -1,0 +1,14 @@
+//
+//  Track+Preview.swift
+//  Project 7 Fast Track
+//
+//  Created by Deirdre Saoirse Moen on 1/31/23.
+//
+
+import Foundation
+
+extension Track {
+	static var track1: Track {
+		Track(trackId: 1, artistName: "Nirvana", trackName: "Smells Like Teen Spirit", previewUrl: URL(string: "abc")!, artworkUrl100: "https://bit.ly/teen-spirit")
+	}
+}

--- a/SwiftUI/project7/FastTrack/TrackView.swift
+++ b/SwiftUI/project7/FastTrack/TrackView.swift
@@ -58,9 +58,8 @@ struct TrackView: View {
 }
 
 struct TrackView_Previews: PreviewProvider {
-    static var previews: some View {
-        TrackView(track: Track(trackId: 1, artistName: "Nirvana", trackName: "Smells Like Teen Spirit", previewUrl: URL(string: "abc")!, artworkUrl100: "https://bit.ly/teen-spirit")) { track in
-
-        }
-    }
+	static var previews: some View {
+		TrackView(track: Track.track1) { track in
+		}
+	}
 }


### PR DESCRIPTION
There are several ways to solve this, but I generally opt to move preview content into the Preview Content directory.

1. Migrated the preview track creation into a Preview Content extension.
2. Updated the PreviewProvider to use the extension.

This is a reproducible crash for me. Below is from my own build's crash logs, but also got them with a fresh pull from your repo.

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_platform.dylib      	       0x18e8a483c os_unfair_lock_lock + 12
1   CoreFoundation                	       0x18e8f8f38 -[__NSArrayM dealloc] + 76
2   Project 7 Fast Track          	       0x1020d5ed0 outlined destroy of ContentView + 60
3   Project 7 Fast Track          	       0x1020d83c4 closure #1 in Project_7_Fast_TrackApp.body.getter + 328 (Project_7_Fast_TrackApp.swift:15)
4   SwiftUI                       	       0x1b66e03ec 0x1b543b000 + 19551212
5   Project 7 Fast Track          	       0x1020d81b8 Project_7_Fast_TrackApp.body.getter + 372 (Project_7_Fast_TrackApp.swift:13)
6   Project 7 Fast Track          	       0x1020d852c protocol witness for App.body.getter in conformance Project_7_Fast_TrackApp + 12
7   SwiftUI                       	       0x1b5bfed98 0x1b543b000 + 8142232
8   SwiftUI                       	       0x1b5fab424 0x1b543b000 + 11994148
9   SwiftUI                       	       0x1b5bfe110 0x1b543b000 + 8139024
10  SwiftUI                       	       0x1b5fab77c 0x1b543b000 + 11995004
11  SwiftUI                       	       0x1b5e0b84c 0x1b543b000 + 10291276
12  AttributeGraph                	       0x1b6cc94b8 AG::Graph::UpdateStack::update() + 520
13  AttributeGraph                	       0x1b6cc9c38 AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 424
14  AttributeGraph                	       0x1b6cd2498 AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, AGSwiftMetadata const*, unsigned char&, long) + 420
15  AttributeGraph                	       0x1b6ce971c AGGraphGetValue + 212
16  SwiftUI                       	       0x1b5fab580 0x1b543b000 + 11994496
17  SwiftUI                       	       0x1b5fab754 0x1b543b000 + 11994964
18  SwiftUI                       	       0x1b5e0b84c 0x1b543b000 + 10291276
19  AttributeGraph                	       0x1b6cc94b8 AG::Graph::UpdateStack::update() + 520
20  AttributeGraph                	       0x1b6cc9c38 AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 424
21  AttributeGraph                	       0x1b6cd2498 AG::Graph::input_value_ref_slow(AG::data::ptr<AG::Node>, AG::AttributeID, unsigned int, AGSwiftMetadata const*, unsigned char&, long) + 420
22  AttributeGraph                	       0x1b6ce971c AGGraphGetValue + 212
23  SwiftUI                       	       0x1b66e11ac 0x1b543b000 + 19554732
24  SwiftUI                       	       0x1b66e128c 0x1b543b000 + 19554956
25  SwiftUI                       	       0x1b5995f90 0x1b543b000 + 5615504
26  AttributeGraph                	       0x1b6cc94b8 AG::Graph::UpdateStack::update() + 520
27  AttributeGraph                	       0x1b6cc9c38 AG::Graph::update_attribute(AG::data::ptr<AG::Node>, unsigned int) + 424
28  AttributeGraph                	       0x1b6cd1b9c AG::Graph::value_ref(AG::AttributeID, AGSwiftMetadata const*, unsigned char&) + 192
29  AttributeGraph                	       0x1b6ce9764 AGGraphGetValue + 284
30  SwiftUI                       	       0x1b5bfbec8 0x1b543b000 + 8130248
31  SwiftUI                       	       0x1b667135c 0x1b543b000 + 19096412
32  SwiftUI                       	       0x1b5bfd338 0x1b543b000 + 8135480
33  SwiftUI                       	       0x1b688a064 0x1b543b000 + 21295204
34  SwiftUI                       	       0x1b669d8a4 0x1b543b000 + 19277988
35  SwiftUI                       	       0x1b669d794 0x1b543b000 + 19277716
36  SwiftUI                       	       0x1b5ec183c 0x1b543b000 + 11036732
37  Project 7 Fast Track          	       0x1020d8468 static Project_7_Fast_TrackApp.$main() + 40 (Project_7_Fast_TrackApp.swift:10)
38  Project 7 Fast Track          	       0x1020d8554 main + 12
39  dyld                          	       0x18e54fe50 start + 2544
